### PR TITLE
extend thread API

### DIFF
--- a/include/bare.h
+++ b/include/bare.h
@@ -22,6 +22,7 @@ typedef void (*bare_suspend_cb)(bare_t *);
 typedef void (*bare_idle_cb)(bare_t *);
 typedef void (*bare_resume_cb)(bare_t *);
 typedef void (*bare_thread_cb)(bare_t *, js_env_t *);
+typedef void (*bare_thread_exit_cb)(bare_t *, js_env_t *);
 
 /** @version 0 */
 struct bare_options_s {
@@ -124,6 +125,9 @@ bare_on_resume (bare_t *bare, bare_resume_cb cb);
  */
 int
 bare_on_thread (bare_t *bare, bare_thread_cb cb);
+
+int
+bare_on_thread_exit (bare_t *bare, bare_thread_exit_cb cb);
 
 #ifdef __cplusplus
 }

--- a/src/bare.c
+++ b/src/bare.c
@@ -48,6 +48,7 @@ bare_setup (uv_loop_t *loop, js_platform_t *platform, js_env_t **env, int argc, 
   process->on_idle = NULL;
   process->on_resume = NULL;
   process->on_thread = NULL;
+  process->on_thread_exit = NULL;
 
   bare_runtime_t *runtime = process->runtime;
 
@@ -151,6 +152,13 @@ bare_on_resume (bare_t *bare, bare_resume_cb cb) {
 int
 bare_on_thread (bare_t *bare, bare_thread_cb cb) {
   bare->process.on_thread = cb;
+
+  return 0;
+}
+
+int
+bare_on_thread_exit (bare_t *bare, bare_thread_exit_cb cb) {
+  bare->process.on_thread_exit = cb;
 
   return 0;
 }

--- a/src/bare.js
+++ b/src/bare.js
@@ -157,6 +157,12 @@ class Bare extends EventEmitter {
     this.emit('exit', bare.exitCode)
   }
 
+  _onthreadexit () {
+    for (const thread of exports.Thread._threads) {
+      if (exports.Thread.hasExited(thread)) thread.emit('exit')
+    }
+  }
+
   _onteardown () {
     this.emit('teardown')
   }
@@ -239,6 +245,7 @@ bare.onuncaughtexception = exports._onuncaughtexception.bind(exports)
 bare.onunhandledrejection = exports._onunhandledrejection.bind(exports)
 bare.onbeforeexit = exports._onbeforeexit.bind(exports)
 bare.onexit = exports._onexit.bind(exports)
+bare.onthreadexit = exports._onthreadexit.bind(exports)
 bare.onteardown = exports._onteardown.bind(exports)
 bare.onsuspend = exports._onsuspend.bind(exports)
 bare.onidle = exports._onidle.bind(exports)

--- a/src/bare.js
+++ b/src/bare.js
@@ -183,6 +183,10 @@ class Bare extends EventEmitter {
     this.emit('resume')
   }
 
+  _onmessage (msg) {
+    this.emit('message', msg)
+  }
+
   [Symbol.for('bare.inspect')] () {
     return {
       __proto__: { constructor: Bare },
@@ -250,6 +254,7 @@ bare.onteardown = exports._onteardown.bind(exports)
 bare.onsuspend = exports._onsuspend.bind(exports)
 bare.onidle = exports._onidle.bind(exports)
 bare.onresume = exports._onresume.bind(exports)
+bare.onmessage = exports._onmessage.bind(exports)
 
 /**
  * Step 8:

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -695,6 +695,30 @@ bare_runtime_setup_thread (js_env_t *env, js_callback_info_t *info) {
 }
 
 static js_value_t *
+bare_runtime_check_thread (js_env_t *env, js_callback_info_t *info) {
+  int err;
+
+  bare_runtime_t *runtime;
+
+  size_t argc = 1;
+  js_value_t *argv[1];
+
+  err = js_get_callback_info(env, info, &argc, argv, NULL, (void **) &runtime);
+  assert(err == 0);
+
+  assert(argc == 1);
+
+  bare_thread_t *thread;
+  err = js_get_value_external(env, argv[0], (void **) &thread);
+  assert(err == 0);
+
+  js_value_t *result;
+  js_create_int32(env, thread->exited == true ? 1 : 0, &result);
+
+  return result;
+}
+
+static js_value_t *
 bare_runtime_join_thread (js_env_t *env, js_callback_info_t *info) {
   int err;
 
@@ -919,6 +943,7 @@ bare_runtime_setup (uv_loop_t *loop, bare_process_t *process, bare_runtime_t *ru
   V("resume", bare_runtime_resume);
 
   V("setupThread", bare_runtime_setup_thread);
+  V("checkThread", bare_runtime_check_thread);
   V("joinThread", bare_runtime_join_thread);
   V("suspendThread", bare_runtime_suspend_thread);
   V("resumeThread", bare_runtime_resume_thread);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -1003,8 +1003,6 @@ bare_runtime_teardown (bare_runtime_t *runtime, int *exit_code) {
 
     if (!runtime->process->runtime->exiting) {
       uv_close((uv_handle_t *) &runtime->signals.exit, bare_runtime_on_handle_close);
-    } else {
-      free(runtime);
     }
   }
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -13,6 +13,124 @@
 #include "runtime.h"
 #include "types.h"
 
+#define MESSAGE_BUFFER_BASE_SIZE 16
+
+static int
+bare_thread_init_message_buffer (bare_thread_message_buffer_t *buffer) {
+  buffer->length = 0;
+  buffer->size = MESSAGE_BUFFER_BASE_SIZE;
+  buffer->data = malloc(buffer->size * sizeof(bare_thread_message_t *));
+
+  if (buffer->data == NULL) {
+    free(buffer->data);
+    return -1;
+  }
+
+  return 0;
+}
+
+static int
+bare_thread_receive_message (js_env_t *env, js_value_t **messages, bare_thread_message_t* message) {
+  int err;
+
+  js_value_t *thread_message;
+
+  switch (message->type) {
+  case bare_thread_message_buffer: {
+    js_value_t *arraybuffer;
+
+    void *data;
+    err = js_create_arraybuffer(env, message->buffer.len, &data, &arraybuffer);
+    assert(err == 0);
+
+    memcpy(data, message->buffer.base, message->buffer.len);
+
+    err = js_create_typedarray(env, js_uint8_array, message->buffer.len, arraybuffer, 0, &thread_message);
+    assert(err == 0);
+    break;
+  }
+
+  case bare_thread_message_arraybuffer: {
+    void *data;
+    err = js_create_arraybuffer(env, message->buffer.len, &data, &thread_message);
+    assert(err == 0);
+
+    memcpy(data, message->buffer.base, message->buffer.len);
+    break;
+  }
+
+  case bare_thread_message_sharedarraybuffer:
+    err = js_create_sharedarraybuffer_with_backing_store(env, message->backing_store, NULL, NULL, &thread_message);
+    assert(err == 0);
+
+    err = js_release_arraybuffer_backing_store(env, message->backing_store);
+    assert(err == 0);
+    break;
+
+  case bare_thread_message_external:
+    err = js_create_external(env, message->external, NULL, NULL, &thread_message);
+    assert(err == 0);
+    break;
+  }
+
+  messages[0] = thread_message;
+
+  free(message);
+
+  assert(err == 0);
+
+  return 0;
+}
+
+static void
+bare_thread_on_message (bare_thread_t *thread) {
+  int err;
+
+  js_env_t *env = thread->runtime->env;
+
+  js_value_t *fn;
+  err = js_get_named_property(env, thread->runtime->exports, "onmessage", &fn);
+  assert(err == 0);
+
+  bool is_set;
+  err = js_is_function(env, fn, &is_set);
+  assert(err == 0);
+
+  bare_thread_message_buffer_t *buffer = thread->message_buffer;
+
+  thread->message_buffer = malloc(sizeof(bare_thread_message_buffer_t));
+  err = bare_thread_init_message_buffer(thread->message_buffer);
+  assert(err == 0);
+
+  if (is_set) {
+    js_value_t *global;
+    err = js_get_global(env, &global);
+    assert(err == 0);
+
+    for (int i = 0; i < buffer->length; i++) {
+      js_value_t *messages[1];
+
+      err = bare_thread_receive_message(env, messages, buffer->data[i]);
+      assert(err == 0);
+
+      err = js_call_function(env, global, fn, 1, messages, NULL);
+      assert(err == 0);
+    }
+  }
+
+  free(buffer->data);
+  free(buffer);
+}
+
+static void
+bare_thread_on_message_signal (uv_async_t *handle) {
+  bare_thread_t *thread = (bare_thread_t *) handle->data;
+
+  uv_unref((uv_handle_t *) &thread->signals.message);
+
+  bare_thread_on_message(thread);
+}
+
 static void
 bare_thread_entry (void *data) {
   int err;
@@ -26,6 +144,9 @@ bare_thread_entry (void *data) {
   assert(err == 0);
 
   err = bare_runtime_setup(&loop, runtime->process, runtime);
+  assert(err == 0);
+
+  err = bare_thread_init_message_buffer(thread->message_buffer);
   assert(err == 0);
 
   if (runtime->process->on_thread) {
@@ -101,6 +222,12 @@ bare_thread_entry (void *data) {
 
   uv_sem_post(&thread->lock);
 
+  uv_async_init(runtime->loop, &thread->signals.message, bare_thread_on_message_signal);
+
+  thread->signals.message.data = (void *) thread;
+
+  uv_unref((uv_handle_t *) &thread->signals.message);
+
   bare_runtime_run(runtime, thread->filename, thread_source);
 
   free(thread->filename);
@@ -140,6 +267,8 @@ bare_thread_create (bare_runtime_t *runtime, const char *filename, bare_thread_s
 
   thread->runtime->process = runtime->process;
 
+  thread->message_buffer = malloc(sizeof(bare_thread_message_buffer_t));
+
   err = uv_sem_init(&thread->lock, 0);
   assert(err == 0);
 
@@ -156,6 +285,8 @@ bare_thread_create (bare_runtime_t *runtime, const char *filename, bare_thread_s
     uv_sem_destroy(&thread->lock);
 
     free(thread->runtime);
+    free(thread->message_buffer->data);
+    free(thread->message_buffer);
     free(thread);
 
     return -1;
@@ -165,6 +296,37 @@ bare_thread_create (bare_runtime_t *runtime, const char *filename, bare_thread_s
   uv_sem_post(&thread->lock);
 
   *result = thread;
+
+  return 0;
+}
+
+static int
+bare_thread_realloc_message_buffer (bare_thread_message_buffer_t *buffer, int size) {
+  void *data = realloc(buffer->data, size);
+  if (data == NULL) {
+    free(buffer->data);
+    return -1;
+  }
+  buffer->size = size;
+  buffer->data = (bare_thread_message_t **) data;
+  return 0;
+}
+
+int
+bare_thread_post_message (bare_thread_t *thread, bare_thread_message_t *message) {
+  int err;
+
+  int size = thread->message_buffer->size;
+
+  if (thread->message_buffer->length + 1 >= size) {
+    err = bare_thread_realloc_message_buffer(thread->message_buffer, size * 2);
+    assert(err == 0);
+  }
+
+  thread->message_buffer->data[thread->message_buffer->length] = message;
+  thread->message_buffer->length++;
+
+  bare_thread_message_t *m = thread->message_buffer->data[0];
 
   return 0;
 }
@@ -179,6 +341,8 @@ bare_thread_join (bare_runtime_t *runtime, bare_thread_t *thread) {
 
   uv_sem_destroy(&thread->lock);
 
+  free(thread->message_buffer->data);
+  free(thread->message_buffer);
   free(thread);
 
   if (err < 0) {

--- a/src/thread.c
+++ b/src/thread.c
@@ -109,6 +109,11 @@ bare_thread_entry (void *data) {
 
   thread->exited = true;
 
+  uv_ref((uv_handle_t *) &runtime->signals.exit);
+
+  err = uv_async_send(&runtime->signals.exit);
+  assert(err == 0);
+
   uv_sem_post(&thread->lock);
 
   err = bare_runtime_teardown(thread->runtime, NULL);

--- a/src/thread.h
+++ b/src/thread.h
@@ -10,6 +10,9 @@ int
 bare_thread_create (bare_runtime_t *runtime, const char *filename, bare_thread_source_t source, bare_thread_data_t data, size_t stack_size, bare_thread_t **result);
 
 int
+bare_thread_post_message (bare_thread_t *thread, bare_thread_message_t *message);
+
+int
 bare_thread_join (bare_runtime_t *runtime, bare_thread_t *thread);
 
 int

--- a/src/thread.js
+++ b/src/thread.js
@@ -62,6 +62,10 @@ module.exports = exports = class Thread extends EventEmitter {
     if (this._handle) bare.resumeThread(this._handle)
   }
 
+  postMessage (data) {
+    if (this._handle) bare.messageThread(this._handle, data)
+  }
+
   [Symbol.for('bare.inspect')] () {
     return {
       __proto__: { constructor: Thread },

--- a/src/thread.js
+++ b/src/thread.js
@@ -1,7 +1,11 @@
 /* global bare, Bare */
 
-module.exports = exports = class Thread {
+const EventEmitter = require('bare-events')
+
+module.exports = exports = class Thread extends EventEmitter {
   constructor (filename, opts, callback) {
+    super()
+
     if (typeof filename === 'function') {
       callback = filename
       filename = '<thread>'
@@ -74,6 +78,11 @@ module.exports = exports = class Thread {
 
   static get isMainThread () {
     return bare.isMainThread
+  }
+
+  static hasExited (thread) {
+    if (!thread._handle) return true
+    return bare.checkThread(thread._handle) === 1
   }
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -27,6 +27,7 @@ struct bare_runtime_s {
   struct {
     uv_async_t suspend;
     uv_async_t resume;
+    uv_async_t exit;
   } signals;
 
   int active_handles;
@@ -52,6 +53,7 @@ struct bare_process_s {
   bare_idle_cb on_idle;
   bare_resume_cb on_resume;
   bare_thread_cb on_thread;
+  bare_thread_exit_cb on_thread_exit;
 };
 
 struct bare_source_s {

--- a/src/types.h
+++ b/src/types.h
@@ -13,6 +13,8 @@ typedef struct bare_source_s bare_source_t;
 typedef struct bare_thread_s bare_thread_t;
 typedef struct bare_thread_source_s bare_thread_source_t;
 typedef struct bare_thread_data_s bare_thread_data_t;
+typedef struct bare_thread_message_s bare_thread_message_t;
+typedef struct bare_thread_message_buffer_s bare_thread_message_buffer_t;
 typedef struct bare_thread_list_s bare_thread_list_t;
 typedef struct bare_module_list_s bare_module_list_t;
 
@@ -96,8 +98,35 @@ struct bare_thread_data_s {
   };
 };
 
+struct bare_thread_message_s {
+  enum {
+    bare_thread_message_buffer,
+    bare_thread_message_arraybuffer,
+    bare_thread_message_sharedarraybuffer,
+    bare_thread_message_external,
+  } type;
+
+  union {
+    uv_buf_t buffer;
+    js_arraybuffer_backing_store_t *backing_store;
+    void *external;
+  };
+};
+
+struct bare_thread_message_buffer_s {
+  int size;
+  int length;
+  bare_thread_message_t **data;
+};
+
 struct bare_thread_s {
   bare_runtime_t *runtime;
+
+  struct {
+    uv_async_t message;
+  } signals;
+
+  bare_thread_message_buffer_t *message_buffer;
 
   uv_thread_t id;
   uv_sem_t lock;

--- a/test/fixtures/thread.js
+++ b/test/fixtures/thread.js
@@ -2,6 +2,8 @@
 const assert = require('bare-assert')
 const { Thread } = Bare
 
+Bare.on('message', msg => console.log('thread received:', msg))
+
 assert(Thread.isMainThread === false)
 
 assert(Thread.self.data.equals(Buffer.from('hello world')))

--- a/test/thread.js
+++ b/test/thread.js
@@ -7,7 +7,13 @@ assert(Thread.isMainThread === true)
 
 const entry = path.join(__dirname, 'fixtures/thread.js')
 
-const thread = new Thread(entry, { data: Buffer.from('hello world') })
-thread.on('exit', () => console.log('thread has exited'))
+const detached = new Thread(entry, { data: Buffer.from('hello world') })
+detached.on('exit', () => console.log('thread has exited'))
 
-thread.join()
+setTimeout(() => {
+  const thread = new Thread(entry, { data: Buffer.from('hello world') })
+  thread.on('exit', () => console.log('thread has exited'))
+
+  thread.join()
+  console.log('all done')
+}, 200) // allow time for detached to exit

--- a/test/thread.js
+++ b/test/thread.js
@@ -10,6 +10,10 @@ const entry = path.join(__dirname, 'fixtures/thread.js')
 const detached = new Thread(entry, { data: Buffer.from('hello world') })
 detached.on('exit', () => console.log('thread has exited'))
 
+detached.postMessage(Buffer.from('hello'))
+detached.postMessage(Buffer.from('hello1'))
+detached.postMessage(Buffer.from('hello2'))
+
 setTimeout(() => {
   const thread = new Thread(entry, { data: Buffer.from('hello world') })
   thread.on('exit', () => console.log('thread has exited'))

--- a/test/thread.js
+++ b/test/thread.js
@@ -8,5 +8,6 @@ assert(Thread.isMainThread === true)
 const entry = path.join(__dirname, 'fixtures/thread.js')
 
 const thread = new Thread(entry, { data: Buffer.from('hello world') })
+thread.on('exit', () => console.log('thread has exited'))
 
 thread.join()


### PR DESCRIPTION
This PR aims to increase parity between the Bare and Nodejs thread APIs.

Specifically aiming for the following API :
- [x] thread emits `exit` event when process exits
- [x] `thread.postMessage` API
- [ ] `MessageChannel` and `MessagePort` for communication between threads
- [ ] `parentPort` export for communication with parent process